### PR TITLE
feat: pool pointers for use with upstream IAM refreshing

### DIFF
--- a/examples/goredis/main.go
+++ b/examples/goredis/main.go
@@ -21,7 +21,7 @@ func main() {
 
 	pool := goredis.NewPool(client)
 
-	rs := redsync.New(pool)
+	rs := redsync.New(&pool)
 
 	mutex := rs.NewMutex("test-redsync")
 

--- a/examples/goredis/v7/main.go
+++ b/examples/goredis/v7/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	pool := goredis.NewPool(client)
 
-	rs := redsync.New(pool)
+	rs := redsync.New(&pool)
 
 	mutex := rs.NewMutex("test-redsync")
 	ctx := context.Background()

--- a/examples/goredis/v8/main.go
+++ b/examples/goredis/v8/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	pool := goredis.NewPool(client)
 
-	rs := redsync.New(pool)
+	rs := redsync.New(&pool)
 
 	mutex := rs.NewMutex("test-redsync")
 	ctx := context.Background()

--- a/examples/goredis/v9/main.go
+++ b/examples/goredis/v9/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	pool := goredis.NewPool(client)
 
-	rs := redsync.New(pool)
+	rs := redsync.New(&pool)
 
 	mutex := rs.NewMutex("test-redsync")
 	ctx := context.Background()

--- a/examples/redigo/main.go
+++ b/examples/redigo/main.go
@@ -28,7 +28,7 @@ func main() {
 		},
 	})
 
-	rs := redsync.New(pool)
+	rs := redsync.New(&pool)
 
 	mutex := rs.NewMutex("test-redsync")
 

--- a/mutex.go
+++ b/mutex.go
@@ -32,7 +32,7 @@ type Mutex struct {
 	shuffle      bool
 	failFast     bool
 
-	pools []redis.Pool
+	pools []*redis.Pool
 }
 
 // Name returns mutex name (i.e. the Redis key).
@@ -270,7 +270,7 @@ func (m *Mutex) actOnPoolsAsync(actFn func(redis.Pool) (bool, error)) (int, erro
 			r := result{node: node}
 			r.statusOK, r.err = actFn(pool)
 			ch <- r
-		}(node, pool)
+		}(node, *pool)
 	}
 
 	var (

--- a/redsync.go
+++ b/redsync.go
@@ -14,11 +14,11 @@ const (
 
 // Redsync provides a simple method for creating distributed mutexes using multiple Redis connection pools.
 type Redsync struct {
-	pools []redis.Pool
+	pools []*redis.Pool
 }
 
 // New creates and returns a new Redsync instance from given Redis connection pools.
-func New(pools ...redis.Pool) *Redsync {
+func New(pools ...*redis.Pool) *Redsync {
 	return &Redsync{
 		pools: pools,
 	}
@@ -143,7 +143,7 @@ func WithShufflePools(b bool) Option {
 }
 
 // randomPools shuffles Redis pools.
-func randomPools(pools []redis.Pool) {
+func randomPools(pools []*redis.Pool) {
 	rand.Shuffle(len(pools), func(i, j int) {
 		pools[i], pools[j] = pools[j], pools[i]
 	})

--- a/redsync_test.go
+++ b/redsync_test.go
@@ -28,7 +28,7 @@ var servers []*tempredis.Server
 
 type testCase struct {
 	poolCount int
-	pools     []redis.Pool
+	pools     []*redis.Pool
 }
 
 func makeCases(poolCount int) map[string]*testCase {
@@ -103,14 +103,14 @@ func TestRedsync(t *testing.T) {
 	}
 }
 
-func newMockPoolsRedigo(n int) []redis.Pool {
-	pools := make([]redis.Pool, n)
+func newMockPoolsRedigo(n int) []*redis.Pool {
+	pools := make([]*redis.Pool, n)
 
 	offset := RedigoBlock * ServerPoolSize
 
 	for i := 0; i < n; i++ {
 		server := servers[i+offset]
-		pools[i] = redigo.NewPool(&redigolib.Pool{
+		p := redigo.NewPool(&redigolib.Pool{
 			MaxIdle:     3,
 			IdleTimeout: 240 * time.Second,
 			Dial: func() (redigolib.Conn, error) {
@@ -121,12 +121,13 @@ func newMockPoolsRedigo(n int) []redis.Pool {
 				return err
 			},
 		})
+		pools[i] = &p
 	}
 	return pools
 }
 
-func newMockPoolsGoredis(n int) []redis.Pool {
-	pools := make([]redis.Pool, n)
+func newMockPoolsGoredis(n int) []*redis.Pool {
+	pools := make([]*redis.Pool, n)
 
 	offset := GoredisBlock * ServerPoolSize
 
@@ -135,13 +136,14 @@ func newMockPoolsGoredis(n int) []redis.Pool {
 			Network: "unix",
 			Addr:    servers[i+offset].Socket(),
 		})
-		pools[i] = goredis.NewPool(client)
+		p := goredis.NewPool(client)
+		pools[i] = &p
 	}
 	return pools
 }
 
-func newMockPoolsGoredisV7(n int) []redis.Pool {
-	pools := make([]redis.Pool, n)
+func newMockPoolsGoredisV7(n int) []*redis.Pool {
+	pools := make([]*redis.Pool, n)
 
 	offset := GoredisV7Block * ServerPoolSize
 
@@ -150,13 +152,14 @@ func newMockPoolsGoredisV7(n int) []redis.Pool {
 			Network: "unix",
 			Addr:    servers[i+offset].Socket(),
 		})
-		pools[i] = goredis_v7.NewPool(client)
+		p := goredis_v7.NewPool(client)
+		pools[i] = &p
 	}
 	return pools
 }
 
-func newMockPoolsGoredisV8(n int) []redis.Pool {
-	pools := make([]redis.Pool, n)
+func newMockPoolsGoredisV8(n int) []*redis.Pool {
+	pools := make([]*redis.Pool, n)
 
 	offset := GoredisV8Block * ServerPoolSize
 
@@ -165,13 +168,14 @@ func newMockPoolsGoredisV8(n int) []redis.Pool {
 			Network: "unix",
 			Addr:    servers[i+offset].Socket(),
 		})
-		pools[i] = goredis_v8.NewPool(client)
+		p := goredis_v8.NewPool(client)
+		pools[i] = &p
 	}
 	return pools
 }
 
-func newMockPoolsGoredisV9(n int) []redis.Pool {
-	pools := make([]redis.Pool, n)
+func newMockPoolsGoredisV9(n int) []*redis.Pool {
+	pools := make([]*redis.Pool, n)
 
 	offset := GoredisV9Block * ServerPoolSize
 
@@ -180,13 +184,14 @@ func newMockPoolsGoredisV9(n int) []redis.Pool {
 			Network: "unix",
 			Addr:    servers[i+offset].Socket(),
 		})
-		pools[i] = goredis_v9.NewPool(client)
+		p := goredis_v9.NewPool(client)
+		pools[i] = &p
 	}
 	return pools
 }
 
-func newMockPoolsRueidis(n int) []redis.Pool {
-	pools := make([]redis.Pool, n)
+func newMockPoolsRueidis(n int) []*redis.Pool {
+	pools := make([]*redis.Pool, n)
 
 	offset := RueidisBlock * ServerPoolSize
 
@@ -197,7 +202,8 @@ func newMockPoolsRueidis(n int) []redis.Pool {
 		if err != nil {
 			panic(err)
 		}
-		pools[i] = rueidis.NewPool(rueidiscompat.NewAdapter(client))
+		p := rueidis.NewPool(rueidiscompat.NewAdapter(client))
+		pools[i] = &p
 	}
 	return pools
 }


### PR DESCRIPTION
Use pointers instead of instantiating redis.Pools so that pools can be kept refreshed upstream with IAM credentials.